### PR TITLE
Add MissingStateError

### DIFF
--- a/authlib/integrations/base_client/__init__.py
+++ b/authlib/integrations/base_client/__init__.py
@@ -5,12 +5,12 @@ from .framework_integration import FrameworkIntegration
 from .errors import (
     OAuthError, MissingRequestTokenError, MissingTokenError,
     TokenExpiredError, InvalidTokenError, UnsupportedTokenTypeError,
-    MismatchingStateError,
+    MismatchingStateError, MissingStateError,
 )
 
 __all__ = [
     'BaseOAuth', 'BaseApp', 'RemoteApp', 'FrameworkIntegration',
     'OAuthError', 'MissingRequestTokenError', 'MissingTokenError',
     'TokenExpiredError', 'InvalidTokenError', 'UnsupportedTokenTypeError',
-    'MismatchingStateError',
+    'MismatchingStateError', 'MissingStateError',
 ]

--- a/authlib/integrations/base_client/base_app.py
+++ b/authlib/integrations/base_client/base_app.py
@@ -4,6 +4,7 @@ from authlib.common.security import generate_token
 from authlib.consts import default_user_agent
 from .errors import (
     MismatchingStateError,
+    MissingStateError,
 )
 
 __all__ = ['BaseApp']
@@ -122,6 +123,8 @@ class BaseApp(object):
     def _retrieve_oauth2_access_token_params(self, request, params):
         request_state = params.pop('state', None)
         state = self.framework.get_session_data(request, 'state')
+        if not state:
+            raise MissingStateError()
         if state != request_state:
             raise MismatchingStateError()
         if state:

--- a/authlib/integrations/base_client/errors.py
+++ b/authlib/integrations/base_client/errors.py
@@ -28,3 +28,8 @@ class UnsupportedTokenTypeError(OAuthError):
 class MismatchingStateError(OAuthError):
     error = 'mismatching_state'
     description = 'CSRF Warning! State not equal in request and response.'
+
+
+class MissingStateError(OAuthError):
+    error = 'missing_state'
+    description = 'CSRF Warning! State missing in request.'


### PR DESCRIPTION
This commit adds a new `MissingStateError` that will be raised before a
`MismatchingStateError` when there is no `state` value in the session.